### PR TITLE
Fix wrong docker release tag in adapters

### DIFF
--- a/.github/workflows/multi-platform.yaml
+++ b/.github/workflows/multi-platform.yaml
@@ -62,10 +62,9 @@ jobs:
             echo RELEASE_CHANNEL=edge >> $GITHUB_ENV
           fi
           echo "Release channel determined to be $RELEASE_CHANNEL"
-          LATEST_VERSION=$(git ls-remote --tags | tail -1 | cut -f2 | sed 's/refs\/tags\///g') >> $GITHUB_ENV
-          GIT_VERSION=$(git ls-remote --tags | tail -1 | cut -f2 | sed 's/refs\/tags\///g') >> $GITHUB_ENV
-          # GIT_VERSION=$(git describe --tags `git rev-list --tags --max-count=1` --always) 
-          GIT_STRIPPED_VERSION=$(git ls-remote --tags | tail -1 | cut -f2 | sed 's/refs\/tags\///g' | cut -c2-)
+          LATEST_VERSION=$(git ls-remote --sort='v:refname' --tags | tail -1 | cut -f2 | sed 's/refs\/tags\///g') >> $GITHUB_ENV
+          GIT_VERSION=$(git ls-remote --sort='v:refname' --tags | tail -1 | cut -f2 | sed 's/refs\/tags\///g') >> $GITHUB_ENV
+          GIT_STRIPPED_VERSION=$(git ls-remote --sort='v:refname' --tags | tail -1 | cut -f2 | sed 's/refs\/tags\///g' | cut -c2-)
           echo "GIT_LATEST=$LATEST_VERSION" >> $GITHUB_ENV
           echo "GIT_VERSION=$GIT_VERSION" >> $GITHUB_ENV
           echo "GIT_STRIPPED_VERSION=$GIT_STRIPPED_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
Signed-off-by: Sujay <sujaydey641@gmail.com>

**Description**

This PR fixes part of [#6408](https://github.com/meshery/meshery/issues/6408)
Fixes wrong docker release tag in [meshery-nsm](https://github.com/meshery/meshery-nsm)

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
