### PR TITLE
Updated the go version in github actions to 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+env:
+  GO_VERSION: '1.20'
+
 name: Meshery NSM
 on:
   push:
@@ -14,14 +17,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@master
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
     - name: Setup Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v4
       with:
-        go-version: ${{ secrets.GO_VERSION }}
-    - run: GOPROXY=direct GOSUMDB=off go get -u golang.org/x/lint/golint; go list ./... | grep -v /vendor/ | xargs -L1 /home/runner/go/bin/golint -set_exit_status
+        go-version: ${{ env.GO_VERSION }}
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.52
+        args: --timeout=5m
   error_check:
     name: Error check
     runs-on: ubuntu-latest
@@ -31,10 +38,10 @@ jobs:
       with:
         fetch-depth: 1
     - name: Setup Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v4
       with:
-        go-version: ${{ secrets.GO_VERSION }}
-    - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go get -u github.com/kisielk/errcheck; /home/runner/go/bin/errcheck -tags draft ./...
+        go-version: ${{ env.GO_VERSION }}
+    - run: go install github.com/kisielk/errcheck@latest; errcheck -tags draft ./...
   static_check:
     name: Static check
     runs-on: ubuntu-latest
@@ -44,10 +51,10 @@ jobs:
       with:
         fetch-depth: 1
     - name: Setup Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v4
       with:
-        go-version: ${{ secrets.GO_VERSION }}
-    - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go get -u honnef.co/go/tools/cmd/staticcheck; PKGS=$(go list ./... | grep -vF /meshes); /home/runner/go/bin/staticcheck -tags draft -checks all $PKGS # https://staticcheck.io/docs/checks
+        go-version: ${{ env.GO_VERSION }}
+    - run: go install honnef.co/go/tools/cmd/staticcheck@latest; PKGS=$(go list ./... | grep -vF /meshes); staticcheck -tags draft -checks all $PKGS # https://staticcheck.io/docs/checks
 #   vet:
 #     name: Vet
 #     runs-on: ubuntu-latest
@@ -59,7 +66,7 @@ jobs:
 #     - name: Setup Go
 #       uses: actions/setup-go@v1
 #       with:
-#         go-version: ${{ secrets.GO_VERSION }}
+#         go-version: ${{ env.GO_VERSION }}
 #     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go vet -tags draft ./...
 #   sec_check:
 #     name: Security check
@@ -72,7 +79,7 @@ jobs:
 #     - name: Setup Go
 #       uses: actions/setup-go@v1
 #       with:
-#         go-version: ${{ secrets.GO_VERSION }}
+#         go-version: ${{ env.GO_VERSION }}
 #     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go get github.com/securego/gosec/cmd/gosec; /home/runner/go/bin/gosec ./... # https://github.com/securego/gosec
 #   tests:
 #     # needs: [lint, error_check, static_check, vet, sec_check]
@@ -86,7 +93,7 @@ jobs:
 #     - name: Setup Go
 #       uses: actions/setup-go@v1
 #       with:
-#         go-version: ${{ secrets.GO_VERSION }}
+#         go-version: ${{ env.GO_VERSION }}
 #     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go test -tags draft ./...
   build:
     name: Build check
@@ -98,7 +105,7 @@ jobs:
       with:
         fetch-depth: 1
     - name: Setup Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v4
       with:
-        go-version: ${{ secrets.GO_VERSION }}
-    - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go build .
+        go-version: ${{ env.GO_VERSION }}
+    - run: go build .

--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -1,3 +1,6 @@
+env:
+  GO_VERSION: 1.20
+
 name: Meshkit Error Codes Utility Runner
 on:
   push:
@@ -21,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: ${{ secrets.GO_VERSION }}
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Run utility
         run: |

--- a/internal/config/releases.go
+++ b/internal/config/releases.go
@@ -3,7 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"sort"
@@ -76,7 +76,7 @@ func GetLatestReleases(releases uint) ([]*Release, error) {
 		return []*Release{}, ErrGetLatestReleases(fmt.Errorf("unexpected status code: %d", resp.StatusCode))
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return []*Release{}, ErrGetLatestReleases(err)
 	}


### PR DESCRIPTION
Switched to explicit declaration of the GO_VERSION variable in the actions files. Earlier the GO_VERSION was being read from the repository secrets.

Fixes: https://github.com/meshery/meshery-nsm/issues/147


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
